### PR TITLE
use more narrow output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ IP geolocation is retrieved from https://ipinfo.io/ who allows for 1000 unauthen
 
 ```
 Usage of ipinfo:
+  -1	display each entry on one row
   -m	merge identical hosts
   -t int
     	number of simultaneous threads (default 30)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jftuga/ipinfo
 
-go 1.21.1
+go 1.24.1
 
 require github.com/olekukonko/tablewriter v0.0.5
 


### PR DESCRIPTION
## Purpose

By default, the output it more narrow.  The old behavior can be invoked by using the newly added `-1` switch.


## New Output

```shell
$ ipinfo 8.8.8.8 1.1.1.1
+----------+--------------------------+---------------------+-----------+---------+
| INPUT/IP |       HOSTNAME/ORG       | CITY/REGION/COUNTRY |  LAT/LON  |  DIST   |
+----------+--------------------------+---------------------+-----------+---------+
| 1.1.1.1  | one.one.one.one          | Brisbane            |  -27.4820 | 9106.50 |
| 1.1.1.1  | AS13335 Cloudflare, Inc. | Queensland          |  153.0136 |         |
|          |                          | AU                  |           |         |
| 8.8.8.8  | dns.google               | Mountain View       |   38.0088 | 2168.73 |
| 8.8.8.8  | AS15169 Google LLC       | California          | -122.1175 |         |
|          |                          | US                  |           |         |
+----------+--------------------------+---------------------+-----------+---------+
```

## Original Output
```shell
$ ipinfo -1 8.8.8.8 1.1.1.1
+---------+---------+-----------------+--------------------------+---------------+------------+---------+-------------------+---------+
|  INPUT  |   IP    |    HOSTNAME     |           ORG            |     CITY      |   REGION   | COUNTRY |      LAT/LON      |  DIST   |
+---------+---------+-----------------+--------------------------+---------------+------------+---------+-------------------+---------+
| 1.1.1.1 | 1.1.1.1 | one.one.one.one | AS13335 Cloudflare, Inc. | Brisbane      | Queensland | AU      | -27.4820,153.0136 | 9106.50 |
| 8.8.8.8 | 8.8.8.8 | dns.google      | AS15169 Google LLC       | Mountain View | California | US      | 38.0088,-122.1175 | 2168.73 |
+---------+---------+-----------------+--------------------------+---------------+------------+---------+-------------------+---------+

```
